### PR TITLE
fixed stars coordinates, rotate starfield as a whole using transform rather than rebuild it each time.

### DIFF
--- a/main/include/Astronomy.h
+++ b/main/include/Astronomy.h
@@ -87,6 +87,14 @@ namespace Caelum
                 LongReal rasc,      LongReal decl,
                 LongReal &azimuth,  LongReal &altitude);
 
+        /** Hour angle is zero for objects on sky meridian, and grows to the east.
+         *  @param jday Astronomical time as julian day.
+         *  @param longitude Observer's longitude in degrees east.
+         *  @param hourAngle Hour angle in degrees east.
+         */
+        static void getVernalEquinoxHourAngle (
+                LongReal jday, LongReal longitude, LongReal& hourAngle);
+
         /** Get the sun's position in the sky in, relative to the horizon.
          *  @param jday Astronomical time as julian day.
          *  @param longitude Observer longitude

--- a/main/include/PointStarfield.h
+++ b/main/include/PointStarfield.h
@@ -116,9 +116,9 @@ namespace Caelum
 
     public:
 	    /** Update function; called from CaelumSystem::updateSubcomponents
-            @param time Time of the day.
+            @param julDay Julian day and time.
 	     */
-	    void _update (float time);
+	    void update (LongReal julDay);
 
         /** Magnitude power scale.
          *  Star magnitudes are logarithming; one magnitude difference
@@ -137,31 +137,13 @@ namespace Caelum
         inline void setMaxPixelSize (Ogre::Real value) { mMaxPixelSize = value; }
         inline Ogre::Real getMaxPixelSize () const { return mMaxPixelSize; }
 
-        void setObserverLatitude (Ogre::Degree value);
+        void setObserverLatitude (Ogre::Degree value) { mObserverLatitude = value; }
         inline Ogre::Degree getObserverLatitude () const { return mObserverLatitude; }
 
-        void setObserverLongitude (Ogre::Degree value);
+        void setObserverLongitude (Ogre::Degree value) { mObserverLongitude = value; }
         inline Ogre::Degree getObserverLongitude () const { return mObserverLongitude; }
 
-    private:
-        Ogre::Degree mObserverPositionRebuildDelta;
-
     public:
-        /** Moving the observer position around causes a starfield rebuild.
-         *  Default value (DEFAULT_OBSERVER_POSITION_REBUILD_DELTA) is 0.1
-         *  degrees which is equivalent to around 170 meters on the earth.
-         *
-         *  This only matters if you compute the observer position every
-         *  frame. Caelum doesn't contain code for that.
-         */
-        inline Ogre::Degree getObserverPositionRebuildDelta () const {
-            return mObserverPositionRebuildDelta;
-        }
-        inline void setObserverPositionRebuildDelta (Ogre::Degree value) {
-            mObserverPositionRebuildDelta = value;
-        }
-
-	    static const Ogre::Degree DEFAULT_OBSERVER_POSITION_REBUILD_DELTA;
 
         /// Material used to draw all the points.
 	    static const Ogre::String STARFIELD_MATERIAL_NAME;

--- a/main/src/Astronomy.cpp
+++ b/main/src/Astronomy.cpp
@@ -75,7 +75,22 @@ namespace Caelum
         z = dist * sinDeg (decl);
     }
 
-	void Astronomy::convertEquatorialToHorizontal (
+    void Astronomy::getVernalEquinoxHourAngle(
+            LongReal jday, LongReal longitude, LongReal& hourAngle)
+    {
+        // julian days since J2000
+        LongReal d = jday - 2451545.0;
+        // julian centuries since J2000
+        LongReal T = d / 36525.0;
+        // Greenweech Mean Sidereal Time in seconds  of a day of 86400s UT1 at 0h UT1
+        LongReal GMST0 = 24110.54841 + 8640184.812866 * T + 0.093104 * (T * T) - 0.0000062 * (T * T * T);
+        // Universal time of day in degrees.
+        LongReal UT = LongReal(fmod(d, 1) * 360);
+        // Hour angle, in degrees
+        hourAngle = GMST0 * (360.0 / 86400.0) + LongReal(180) + UT + longitude;
+    }
+
+    void Astronomy::convertEquatorialToHorizontal (
             LongReal jday,
             LongReal longitude,   LongReal latitude,
             LongReal rasc,        LongReal decl,

--- a/main/src/CaelumSystem.cpp
+++ b/main/src/CaelumSystem.cpp
@@ -463,7 +463,7 @@ namespace Caelum
         if (getPointStarfield ()) {
             getPointStarfield ()->setObserverLatitude (getObserverLatitude ());
             getPointStarfield ()->setObserverLongitude (getObserverLongitude ());
-            getPointStarfield ()->_update (relDayTime);
+            getPointStarfield ()->update (julDay);
         }
 
         // Update skydome.


### PR DESCRIPTION
This fix places stars in physically accurate locations. Also starfield mesh is rotated rather than rebuilt due to the Earth rotation.