### PR TITLE
fixed warning C4834: discarding return value of function with 'nodiscard' attribute

### DIFF
--- a/main/include/CaelumPrerequisites.h
+++ b/main/include/CaelumPrerequisites.h
@@ -51,7 +51,9 @@
     #else
         #define CAELUM_SCRIPT_SUPPORT 0
     #endif
-#else
+#endif
+
+#if CAELUM_SCRIPT_SUPPORT
     #if !(OGRE_VERSION > 0x00010600)
         #error "Caelum script support requires Ogre 1.6."
     #endif

--- a/main/src/CaelumSystem.cpp
+++ b/main/src/CaelumSystem.cpp
@@ -355,7 +355,7 @@ namespace Caelum
 
     void CaelumSystem::setDepthComposer (DepthComposer* ptr) {
         mDepthComposer.reset(ptr);
-        if (getAutoAttachViewportsToComponents() && getDepthComposer ()) {
+        if (getDepthComposer() && getAutoAttachViewportsToComponents()) {
             std::for_each (
                     mAttachedViewports.begin(), mAttachedViewports.end(),
                     std::bind1st (

--- a/main/src/GroundFog.cpp
+++ b/main/src/GroundFog.cpp
@@ -188,7 +188,7 @@ namespace Caelum
             mPassFogParams.push_back(PassFogParams((*it)->getFragmentProgramParameters()));
         }
         std::sort(mPassFogParams.begin(), mPassFogParams.end(), PassFogParams::lessThanByParams);
-        std::unique(mPassFogParams.begin(), mPassFogParams.end(), PassFogParams::equalByParams);
+        mPassFogParams.erase(std::unique(mPassFogParams.begin(), mPassFogParams.end(), PassFogParams::equalByParams), mPassFogParams.end());
     }
 
     void GroundFog::FogParamsBase::setup(Ogre::GpuProgramParametersSharedPtr fpParams) {


### PR DESCRIPTION
std::erase should be called after std::unique/remove/etc